### PR TITLE
Removed newtonsoft. Bumped nuget

### DIFF
--- a/SpellTomePriceFixPatcher/Program.cs
+++ b/SpellTomePriceFixPatcher/Program.cs
@@ -17,15 +17,8 @@ namespace SpellTomePriceFixPatcher
         {
             return SynthesisPipeline.Instance
                 .AddPatch<ISkyrimMod, ISkyrimModGetter>(RunPatch)
-                .Run(args, new RunPreferences()
-                {
-                    ActionsForEmptyArgs = new RunDefaultPatcher()
-                    {
-                        IdentifyingModKey = "SpellTomePriceFixPatcher.esp",
-                        BlockAutomaticExit = true,
-                        TargetRelease = GameRelease.SkyrimSE
-                    }
-                });
+                .SetTypicalOpen(GameRelease.SkyrimSE, "SpellTomePriceFixPatcher.esp")
+                .Run(args);
         }
 
         public static void RunPatch(IPatcherState<ISkyrimMod, ISkyrimModGetter> state)

--- a/SpellTomePriceFixPatcher/SpellTomePriceFixPatcher.csproj
+++ b/SpellTomePriceFixPatcher/SpellTomePriceFixPatcher.csproj
@@ -1,18 +1,18 @@
-<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
-    </PropertyGroup>
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net5.0</TargetFramework>
+    <TargetPlatformIdentifier>Windows</TargetPlatformIdentifier>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Mutagen.Bethesda" Version="0.25.0" />
-        <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="1.0.0" />
-        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.13.2" />
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Mutagen.Bethesda" Version="0.28.0" />
+    <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="2.0.0" />
+    <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.17.5" />
+  </ItemGroup>
 
-    <ItemGroup>
-      <Folder Include="Data\" />
-    </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Data\" />
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Listing newtonsoft explicitly in the packages to import has an undesirable side effect.

Since mutagen itself uses newtonsoft, it's possible for a newer version of mutagen to also update newtonsoft it uses.

Since you explicitly list newtonsoft yourself, now your listed version is lower than what mutagen thinks it needs and fails to build.

If you remove it, then it'll be implicitly brought in, and automatically match whatever version mutagen is using